### PR TITLE
(WIP) S3 domain url change

### DIFF
--- a/firefly.yml
+++ b/firefly.yml
@@ -7,6 +7,7 @@ contexts:
     region: ${AWS_DEFAULT_REGION}
     bucket: firefly-aws
     is_extension: true
+    s3_domain_url: ${S3_DOMAIN_URL}
 #    storage:
 #      services:
 #        s3: ~

--- a/src/firefly_aws/domain/service/lambda_executor.py
+++ b/src/firefly_aws/domain/service/lambda_executor.py
@@ -312,7 +312,7 @@ class LambdaExecutor(ff.DomainService, domain.ResourceNameAware):
             download_url = self._s3_service.store_download(body, apply_compression=False)
             s3_domain_url = self._configuration.contexts.get('firefly_aws').get('s3_domain_url')
             if s3_domain_url:
-                download_url = re.sub('[^(https|http)://].+\.com', s3_domain_url, download_url)
+                download_url = re.sub('(?<=http://)|(?<=https://)(.*)(?=tmp)', s3_domain_url, download_url)
 
             ret['body'] = json.dumps({
                 'location': download_url

--- a/src/firefly_aws/domain/service/lambda_executor.py
+++ b/src/firefly_aws/domain/service/lambda_executor.py
@@ -312,7 +312,7 @@ class LambdaExecutor(ff.DomainService, domain.ResourceNameAware):
             download_url = self._s3_service.store_download(body, apply_compression=False)
             s3_domain_url = self._configuration.contexts.get('firefly_aws').get('s3_domain_url')
             if s3_domain_url:
-                download_url = re.sub('(?<=http://)|(?<=https://)(.*)(?=tmp)', s3_domain_url, download_url)
+                download_url = re.sub('(?<=http://)|(?<=https://)(.*)(?=/tmp)', s3_domain_url, download_url)
 
             ret['body'] = json.dumps({
                 'location': download_url

--- a/src/firefly_aws/domain/service/lambda_executor.py
+++ b/src/firefly_aws/domain/service/lambda_executor.py
@@ -310,6 +310,10 @@ class LambdaExecutor(ff.DomainService, domain.ResourceNameAware):
 
         if len(body) > 10000000:
             download_url = self._s3_service.store_download(body, apply_compression=False)
+            s3_domain_url = self._configuration.contexts.get('firefly_aws').get('s3_domain_url')
+            if s3_domain_url:
+                download_url = re.sub('[^(https|http)://].+\.com', s3_domain_url, download_url)
+
             ret['body'] = json.dumps({
                 'location': download_url
             })

--- a/src/firefly_aws/infrastructure/service/agent/aws_agent.py
+++ b/src/firefly_aws/infrastructure/service/agent/aws_agent.py
@@ -1009,6 +1009,9 @@ class AwsAgent(ff.Agent, ResourceNameAware, ff.LoggerAware):
             'BUCKET': self._bucket,
             'DDB_TABLE': self._ddb_table_name(context.name),
         }
+        
+        if self._configuration.contexts['firefly_aws'].config.get('s3_domain_url') is not None:
+            defaults['S3_DOMAIN_URL'] = self._configuration.contexts['firefly_aws'].config.get('s3_domain_url')
 
         if self._adaptive_memory is not None:
             defaults['ADAPTIVE_MEMORY'] = self._adaptive_memory

--- a/src/firefly_aws/infrastructure/service/agent/aws_agent.py
+++ b/src/firefly_aws/infrastructure/service/agent/aws_agent.py
@@ -1010,6 +1010,8 @@ class AwsAgent(ff.Agent, ResourceNameAware, ff.LoggerAware):
             'DDB_TABLE': self._ddb_table_name(context.name),
         }
         
+        print("THIS IS LAMBDA EXECUTOR", self._configuration.contexts['firefly_aws'].config.__dict__)
+        print("THIS IS LAMBDA EXECUTOR", self._configuration.contexts['firefly_aws'].config)
         if self._configuration.contexts['firefly_aws'].config.get('s3_domain_url') is not None:
             defaults['S3_DOMAIN_URL'] = self._configuration.contexts['firefly_aws'].config.get('s3_domain_url')
 

--- a/src/firefly_aws/infrastructure/service/agent/aws_agent.py
+++ b/src/firefly_aws/infrastructure/service/agent/aws_agent.py
@@ -1010,8 +1010,6 @@ class AwsAgent(ff.Agent, ResourceNameAware, ff.LoggerAware):
             'DDB_TABLE': self._ddb_table_name(context.name),
         }
         
-        print("THIS IS LAMBDA EXECUTOR", self._configuration.contexts['firefly_aws'].config.__dict__)
-        print("THIS IS LAMBDA EXECUTOR", self._configuration.contexts['firefly_aws'].config)
         if self._configuration.contexts['firefly_aws'].config.get('s3_domain_url') is not None:
             defaults['S3_DOMAIN_URL'] = self._configuration.contexts['firefly_aws'].config.get('s3_domain_url')
 

--- a/tests/unit/domain/service/test_lambda_executor.py
+++ b/tests/unit/domain/service/test_lambda_executor.py
@@ -1,4 +1,9 @@
 import pytest
+import random
+import string
+import re
+
+from unittest import mock
 from firefly_aws.domain import LambdaExecutor
 from firefly_aws.application import Container
 import firefly.infrastructure as ff_infra
@@ -10,3 +15,27 @@ def sut():
     ret._serializer = ff_infra.JsonSerializer()
 
     return ret
+
+def make_body(size):
+    return ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(size))
+
+def test_handle_http_response_body_upper_limit_calls_s3_service_and_changes_location_url(sut):
+    UPPER_LIMIT = 10000001
+    FAKE_DOMAIN = 'www.fake-domain.com'
+    sut._serializer.serialize = mock.MagicMock()
+    sut._serializer.serialize.return_value = make_body(UPPER_LIMIT)
+    sut._s3_service.store_download = mock.MagicMock()
+    sut._s3_service.store_download.return_value = 'https://fake-s3-bucket.amazonaws.com//tmp/fake-pre-signed-url'
+    sut._configuration.environments = {
+        'S3_DOMAIN_URL': FAKE_DOMAIN
+    }
+
+    ret = sut._handle_http_response({})
+
+    sut._serializer.serialize.assert_called()
+    sut._s3_service.store_download.assert_called()
+    assert 'body' in ret
+    assert 'headers' in ret
+    assert 'location' in ret.get('body')
+    assert 'Location' in ret.get('headers')
+    assert FAKE_DOMAIN in ret.get('headers').get('Location')


### PR DESCRIPTION
Following `303` redirects, the s3 bucket url for the downloadable json file for large datasets is failing to provide Tableau WDC with the necessary CORS in the response headers.

In order not to enable this `access-control-allow-origin` to be present from the bucket, AWS Cloudfront with CORS enabled can be used. For that, it is necessary for the download url to use a valid domain - already configured - instead.

This PR attempts to add a configuration parameter to `firefly.yml` and use it alongside the response builder method prior to enveloping and returning it.